### PR TITLE
Allow custom http headers to be POSTed to UA

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -291,7 +291,10 @@ Visitor.prototype = {
 			var params = self._queue.shift()
 			var path = config.hostname + config.path + "?" + qs.stringify(params);
 			self._log(count++ + ": " + JSON.stringify(params));
-			request.post(path, fn);
+			var options = {
+				headers: self.options.headers || {}
+			};
+			request.post(path, options, fn);
 		}
 
 		async.whilst(test, iterator, function (err) {

--- a/test/send.js
+++ b/test/send.js
@@ -19,7 +19,7 @@ describe("ua", function () {
 		var post;
 
 		beforeEach(function () {
-			post = sinon.stub(request, "post").callsArg(1);
+			post = sinon.stub(request, "post").callsArg(2);
 		});
 
 		afterEach(function () {
@@ -68,7 +68,33 @@ describe("ua", function () {
 			var visitor = ua();
 			visitor._queue.push.apply(visitor._queue, paramSets)
 			visitor.send(fn);
-		})
+		});
+
+		it("should add custom headers to request header", function (done) {
+			var fn = sinon.spy(function () {
+				fn.calledOnce.should.equal(true, "callback should have been called once");
+				fn.thisValues[0].should.equal(visitor, "callback should be called in the context of the visitor instance");
+
+				post.calledOnce.should.equal(true, "request should have been POSTed");
+
+				var parsedUrl = url.parse(post.args[0][0]);
+				var options = post.args[0][1];
+
+				(parsedUrl.protocol + "//" + parsedUrl.host).should.equal(config.hostname);
+
+				options.should.have.keys(["headers"]);
+				options.headers.should.have.key("User-Agent");
+				options.headers["User-Agent"].should.equal("Test User Agent");
+
+				done();
+			});
+
+			var visitor = ua({
+				headers: {'User-Agent': 'Test User Agent'}
+			});
+			visitor._queue.push({});
+			visitor.send(fn);
+		});
 
 	})
 


### PR DESCRIPTION
This is to fix #2 . Instead of passing just an `User-Agent` header option, I figure it would be better to just pass the whole header string, as part of the constructor options.
