### PR TITLE
Builds on node 0.6 - SSL ERROR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
-  - 0.10
+  - "0.10"
 
 before_install: npm conf set strict-ssl false


### PR DESCRIPTION
[CERT SSL ERROR](https://github.com/npm/npm/issues/4391) - cert expired, moreover node <=0.6 is not supported by node/npm team.
