### PR TITLE
Accept document location or page path

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ visitor.pageview({dp: "/", dt: "Welcome", dh: "http://joergtillmann.com"}).send(
 
 This code has the exact same effect as the one above. `dp`, `dt`, and `dh` (as in 'document path', 'document title' and 'document hostname') are the attribute names used by the Measurement Protocol.
 
-The page path (or `dp`) is  mandatory. Google Analytics can not track a pageview without a path. To avoid such erroneous requests, `universal-analytics` will deny `pageview()` tracking if the path is omitted.
+It's mandatory to specify either the page path (`dp`) or document location (`dl`). Google Analytics can not track a pageview without a path. To avoid such erroneous requests, `universal-analytics` will deny `pageview()` tracking if the required parameters are omitted.
 
 ```javascript
 var pagePath = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,8 +120,8 @@ Visitor.prototype = {
 
 		this._tidyParameters(params);
 
-		if (!params.dp) {
-			return this._handleError("Please provide at least a page path (dp)", fn);
+		if (!params.dp && !params.dl) {
+			return this._handleError("Please provide either a page path (dp) or a document location (dl)", fn);
 		}
 
 		return this._withContext(params)._enqueue("pageview", params, fn);
@@ -416,10 +416,10 @@ Visitor.prototype = {
 			this._log("Warning! Unsupported tracking parameter " + param + " (" + params[param] + ")");
 		}
 	},
-	
+
 	_translateParams: function (params) {
         var translated = {};
-        for (var key in params) {        
+        for (var key in params) {
             if (config.parametersMap.hasOwnProperty(key)) {
                 translated[config.parametersMap[key]] = params[key];
             } else {

--- a/test/pageview.js
+++ b/test/pageview.js
@@ -235,7 +235,26 @@ describe("ua", function () {
 			_enqueue.args[2][1].dt.should.equal(title2);
 		})
 
-		it("should fail without page path", function () {
+		it("should accept document location instead of page path", function () {
+			var params = {
+				dl: "http://www.google.com/" + Math.random()
+			};
+			var json = JSON.stringify(params)
+			var fn = sinon.spy()
+
+			ua("UA-XXXXX-XX").pageview(params, fn)
+
+			_enqueue.calledOnce.should.equal(true, "#_enqueue should have been called once");
+			_enqueue.args[0][0].should.equal("pageview");
+			_enqueue.args[0][1].should.have.keys(["dl"]);
+			_enqueue.args[0][1].dl.should.equal(params.dl);
+
+			fn.calledOnce.should.equal(true, "callback should have been called once");
+
+			JSON.stringify(params).should.equal(json, "params should not have been modified")
+		});
+
+		it("should fail without page path or document location", function () {
 			var fn = sinon.spy()
 			var visitor = ua()
 


### PR DESCRIPTION
According to the [docs](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dl), a pageview can specify either document location (`dl`) or path and host (`dp` and `dh`). Currently, the library doesn't allow the usage of just `dl`. This PR makes that change.