### PR TITLE
add a .set function for persistent parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,11 @@ Visitor.prototype = {
 		return this;
 	},
 
+	set: function (key, value) {
+		this._context = this._context || {};
+		this._context.persistentParams = this._context.persistentParams || {};
+		this._context.persistentParams[key] = value;
+	},
 
 	pageview: function (path, hostname, title, params, fn) {
 
@@ -111,7 +116,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.dp = path || params.dp || this._context.dp;
 		params.dh = hostname || params.dh || this._context.dh;
@@ -146,7 +151,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.ec = category || params.ec || this._context.ec;
 		params.ea = action || params.ea || this._context.ea;
@@ -189,7 +194,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.ti = transaction || params.ti || this._context.ti;
 		params.tr = revenue || params.tr || this._context.tr;
@@ -232,7 +237,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.ip = price || params.ip || this._context.ip;
 		params.iq = quantity || params.iq || this._context.iq;
@@ -268,7 +273,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.exd = description || params.exd || this._context.exd;
 		params.exf = +!!(fatal || params.exf || this._context.exf);
@@ -304,7 +309,7 @@ Visitor.prototype = {
 			params = null;
 		}
 
-		params = _.extend({}, params);
+		params = _.extend({}, params, this._context.persistentParams || {});
 
 		params.utc = category || params.utc || this._context.utc;
 		params.utv = variable || params.utv || this._context.utv;
@@ -329,7 +334,7 @@ Visitor.prototype = {
 		}
 
 		var iterator = function (fn) {
-			var params = self._queue.shift()
+			var params = self._queue.shift();
 			var path = config.hostname + config.path;
 			self._log(count++ + ": " + JSON.stringify(params));
 			var options = {


### PR DESCRIPTION
Addresses #34

This PR adds a `.set` method to set any persistent params.
This is particularly useful for things like `uid` (user id) and custom dimensions, for example setting something like "account type" on all events/pageviews for the user.

It is modelled after the set method in analytics.js

There is currently nothing for setting the scope (hit, session, user), but since this is being used from the server and generally on a per-request basis, it is much less important.

Still needs tests, but I can verify it is working.