### PR TITLE
bump async version to 1.2.x+ to solve requirejs problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "request": "2.x",
     "underscore": "1.x",
     "node-uuid": "1.x",
-    "async": "0.2.x"
+    "async": "1.2.x"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
Error log -
```bash
[8330:0624/175142:INFO:CONSOLE(141)] "Uncaught Error: Mismatched anonymous define() module: function () {
            return async;
        }
http://requirejs.org/docs/errors.html#mismatch", source: 
```

After digging out the problem, it seems that this bug has been solved in async#1.2.0 here -  https://github.com/caolan/async/commit/39e1e657ed1632c6e7c3c7a0a77118ef41e90c08

So this patch is just update the dependency version from 0.2.x to 1.2.x to solve this bug.