### PR TITLE
Added possibility of overwrite the hostname of google analytics to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Starting with Universal Analytics, a UUID v4 is the preferred user ID format. It
 var visitor = ua('UA-XXXX-XX', 'CUSTOM_USERID_1', {strictCidFormat: false});
 ```
 
+If you want to use Google Analytics in https protocol, just include it in the options `https: true`, by default will use http:
+```javascript
+var visitor = ua('UA-XXXX-XX', {https: true});
+```
+
 Tracking a pageview without much else is now very simple:
 
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var uuid = require("node-uuid");
 
 var utils = require("./utils");
 var config = require("./config");
+var url = require("url");
 
 module.exports = init;
 
@@ -28,6 +29,11 @@ var Visitor = module.exports.Visitor = function (tid, cid, options, context) {
 	this._queue = [];
 
 	this.options = options || {};
+
+	if (this.options.https) {
+		var parsedHostname = url.parse(config.hostname);
+		config.hostname = 'https://' + parsedHostname.host;
+	}
 
 	this._context = context || {};
 


### PR DESCRIPTION
With the current library you only can connect to google analytics through http and not https, with this change you give the option to the user to change the protocol to https