### PR TITLE
fixes typo in the error handler for events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ Visitor.prototype = {
 		this._tidyParameters(params);
 
 		if (!params.ec || !params.ea) {
-			return this._handleError("Please provide at least an event category (ea) and an event action (ea)", fn);
+			return this._handleError("Please provide at least an event category (ec) and an event action (ea)", fn);
 		}
 
 		return this._withContext(params)._enqueue("event", params, fn);


### PR DESCRIPTION
should be `ec` for event categories