### PR TITLE
translate event parameters before validation of `ea` and `ec`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,7 @@ Visitor.prototype = {
 		delete params.dp;
 		this._tidyParameters(params);
 
+		params = this._translateParams(params);
 		if (!params.ec || !params.ea) {
 			return this._handleError("Please provide at least an event category (ea) and an event action (ea)", fn);
 		}


### PR DESCRIPTION
When sending constructing an event, there is some degree of validation that occurs. Unfortunately, this validation occurs prior to parameter translation.

As such, using `eventCategory` and `eventAction` instead of `ec` and `ea`, respectively, leads to a failure to construct the event.

This PR seeks to address this issue by performing a round of translation prior to validation.