### PR TITLE
Add requestOptions to options to allow custom modifications for the request call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,8 @@ var Visitor = module.exports.Visitor = function (tid, cid, options, context) {
 		cid = null;
 	}
 
+	this.requestOptions = options.requestOptions || {};
+
 	this._queue = [];
 
 	this.options = options || {};
@@ -336,13 +338,13 @@ Visitor.prototype = {
 		}
 
 		var iterator = function (fn) {
-			var params = self._queue.shift()
+			var params = self._queue.shift();
 			var path = config.hostname + config.path;
 			self._log(count++ + ": " + JSON.stringify(params));
-			var options = {
-				form: params,
-				headers: self.options.headers || {}
-			};
+			var options = self.requestOptions;
+			options['form'] = params;
+			options['headers'] = self.requestOptions['headers'] || self.options.headers || {};
+
 			request.post(path, options, fn);
 		}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,11 +26,11 @@ var Visitor = module.exports.Visitor = function (tid, cid, options, context) {
 		cid = null;
 	}
 
-	this.requestOptions = options.requestOptions || {};
-
 	this._queue = [];
 
 	this.options = options || {};
+
+	this.requestOptions = this.options.requestOptions || {};
 
 	if (this.options.https) {
 		var parsedHostname = url.parse(config.hostname);
@@ -341,10 +341,9 @@ Visitor.prototype = {
 			var params = self._queue.shift();
 			var path = config.hostname + config.path;
 			self._log(count++ + ": " + JSON.stringify(params));
-			var options = self.requestOptions;
+			var options = JSON.parse(JSON.stringify(self.requestOptions));
 			options['form'] = params;
 			options['headers'] = self.requestOptions['headers'] || self.options.headers || {};
-
 			request.post(path, options, fn);
 		}
 

--- a/test/send.js
+++ b/test/send.js
@@ -56,7 +56,7 @@ describe("ua", function () {
 					var params = paramSets[i];
 					var args = post.args[i];
 
-					var parsedUrl = url.parse(args[0])
+					var parsedUrl = url.parse(args[0]);
 
 					Math.random(); // I have absolutely no idea why it fails unless there was some processing to be done after url.parse…
 
@@ -64,11 +64,11 @@ describe("ua", function () {
 					args[1].form.should.equal(params);
 				}
 
-				done()
+				done();
 			});
 
 			var visitor = ua();
-			visitor._queue.push.apply(visitor._queue, paramSets)
+			visitor._queue.push.apply(visitor._queue, paramSets);
 			visitor.send(fn);
 		});
 


### PR DESCRIPTION
We needed additional options in every call to request in our system for internal Metrics. 
To prevent a breaking change, headers can still be added through the options.headers param.
