### PR TITLE
use https by default when submitting to GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Starting with Universal Analytics, a UUID v4 is the preferred user ID format. It
 var visitor = ua('UA-XXXX-XX', 'CUSTOM_USERID_1', {strictCidFormat: false});
 ```
 
-If you want to use Google Analytics in https protocol, just include it in the options `https: true`, by default will use http:
+If you want to use Google Analytics in http protocol, just include it in the options `http: true`, by default will use https:
 ```javascript
-var visitor = ua('UA-XXXX-XX', {https: true});
+var visitor = ua('UA-XXXX-XX', {http: true});
 ```
 
 Tracking a pageview without much else is now very simple:

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	protocolVersion: "1",
-	hostname: "http://www.google-analytics.com",
+	hostname: "https://www.google-analytics.com",
 	path: "/collect",
 	batchPath: "/batch",
 	batching: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,9 +37,9 @@ var Visitor = module.exports.Visitor = function (tid, cid, options, context, per
     config.path = this.options.path;
   }
 
-  if (this.options.https) {
+  if (this.options.http) {
     var parsedHostname = url.parse(config.hostname);
-    config.hostname = 'https://' + parsedHostname.host;
+    config.hostname = 'http://' + parsedHostname.host;
   }
 
   if(this.options.enableBatching !== undefined) {


### PR DESCRIPTION
HTTPS should be the standard in 2017. It should be the default mode of transmission to GA, therefore.

This would likely be a breaking change, though.

#24 