### PR TITLE
adding documention on how to use custom dimensions, as it is a bit co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,17 +505,16 @@ In this example the event category ("Mail Server") is not repeated in the second
 Some parameters should be in every tracking call, such as a user ID or custom dimensions that never or hardly change. For such situations a `#set(key, value)` method is available
 
 ```javascript
-  visitor.set("uid", "123456789")
+  visitor.set("uid", "123456789");
 ```
 
 The uid parameter will be part of every tracking request of that visitor from now on.
 
+For custom dimensions, you will not pass `dimension#` rather `cd#`:
 
-
-
-
-
-
+```javascript
+ visitor.set("cd[1-20]", "123456789"); // [1-20] will be the dimension number
+```
 
 # Session-based identification
 


### PR DESCRIPTION
…nfusing compared to what google tells you to set/send in the Admin.

Not sure if this is less confusing to other people, although I spent a good couple days debugging and not seeing my dimensions showing in the next days analytics. Turned on debugging to see the Warning which helped. Ended up looking in the code, which also isn't all that easy to figure it out until I found this issue: #43 . 

When you add a dimension GA tells you this: 
![image](https://user-images.githubusercontent.com/151590/27739812-7bbf7c50-5d75-11e7-9545-60173bd01e84.png)

So, I was passing 'dimension1' instead of 'cd1'. Anyways, let me know if this is useful.