### PR TITLE
replace proprietary logging with `debug` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,11 +540,10 @@ var visitor = ua.createFromSession(socket.handshake.session);
 
 # Debug mode
 
-`universal-analytics` can be instructed to output information during tracking by enabling the debug mode:
+`universal-analytics` is using the [`debug`](https://www.npmjs.com/package/debug) library. It can be instructed to output information during tracking by setting the `DEBUG` environment variable:
 
-```javascript
-var visitor = ua("UA-XXXX-XX").debug()
-// … and so forth.
+```
+DEBUG=universal-analytics
 ```
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ var utils = require("./utils");
 var config = require("./config");
 var url = require("url");
 
+var debug = require("debug")("universal-analytics");
+
 module.exports = init;
 
 
@@ -102,9 +104,9 @@ module.exports.createFromSession = function (session) {
 
 Visitor.prototype = {
 
-  debug: function (debug) {
-    this.options.debug = arguments.length === 0 ? true : debug;
-    this._log("Logging enabled")
+  debug: function (d) {
+    debug.enabled = arguments.length === 0 ? true : d;
+    debug("visitor.debug() is deprecated: set DEBUG=universal-analytics to enable logging")
     return this;
   },
 
@@ -405,14 +407,14 @@ Visitor.prototype = {
     var self = this;
     var count = 1;
     var fn = fn || function () {};
-    self._log("Sending " + self._queue.length + " tracking call(s)");
+    debug("Sending %d tracking call(s)", self._queue.length);
 
     var getBody = function(params) {
       return params.map(function(x) { return querystring.stringify(x); }).join("\n");
     }
 
     var onFinish = function (err) {
-      self._log("Finished sending tracking calls")
+      debug("Finished sending tracking calls")
       fn.call(self, err || null, count - 1);
     }
 
@@ -432,7 +434,7 @@ Visitor.prototype = {
 
       var path = config.hostname + (useBatchPath ? config.batchPath :config.path);
 
-      self._log(count++ + ": " + JSON.stringify(params));
+      debug("%d: %o", count++, params);
 
       var options = Object.assign({}, self.options.requestOptions, {
         body: getBody(params),
@@ -472,11 +474,11 @@ Visitor.prototype = {
 
     this._queue.push(params);
 
-    if (this.options.debug) {
+    if (debug.enabled) {
       this._checkParameters(params);
     }
 
-    this._log("Enqueued " + type + " (" + JSON.stringify(params) + ")");
+    debug("Enqueued %s (%o)", type, params);
 
     if (fn) {
       this.send(fn);
@@ -487,7 +489,7 @@ Visitor.prototype = {
 
 
   _handleError: function (message, fn) {
-      this._log("Error: " + message)
+      debug("Error: %s", message)
       fn && fn.call(this, new Error(message))
       return this;
   },
@@ -503,7 +505,7 @@ Visitor.prototype = {
       for (var i = 0; i < lastItem; i++) {
         id = utils.ensureValidCid(args[i]);
         if (id !== false) return id;
-        if (id != null) this._log("Warning! Invalid UUID format '" + args[i] + "'");
+        if (id != null) debug("Warning! Invalid UUID format '%s'", args[i]);
       }
     } else {
       for (var i = 0; i < lastItem; i++) {
@@ -521,7 +523,7 @@ Visitor.prototype = {
         }).length) {
         continue;
       }
-      this._log("Warning! Unsupported tracking parameter " + param + " (" + params[param] + ")");
+      debug("Warning! Unsupported tracking parameter %s (%s)", param, params[param]);
     }
   },
 
@@ -545,12 +547,6 @@ Visitor.prototype = {
     }
     return params;
   },
-
-
-  _log: function (message) {
-    this.options.debug && console.log("[universal-analytics] " + message);
-  },
-
 
   _withContext: function (context) {
     var visitor = new Visitor(this.tid, this.cid, this.options, context, this._persistentParams);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "tracking"
   ],
   "dependencies": {
+    "debug": "^3.0.0",
     "request": "2.x",
     "uuid": "^3.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -84,11 +84,11 @@ describe("ua", function () {
 			tid: "UA-XXXXX-XX",
 			cid: "custom-format-cid"
 		};
-		
+
 		var next = sinon.spy(uuid, 'v4')
 
 		var visitor = ua(options);
-	
+
 		next.calledOnce.should.equal(true, "next() should've been called once")
 		var generatedCid = next.returnValues[0]
 		uuid.v4.restore()
@@ -103,11 +103,11 @@ describe("ua", function () {
 			cid: "custom-format-cid",
 			strictCidFormat: false
 		};
-	
+
 		var next = sinon.spy(uuid, 'v4')
 
 		var visitor = ua(options);
-	
+
 		next.called.should.equal(false, "next() should't be called")
 		uuid.v4.restore()
 
@@ -116,15 +116,15 @@ describe("ua", function () {
 
 
 	describe("params", function () {
-	
+
 	    var visitor;
-	    
+
 	    before(function () {
 	    	var tid = "UA-XXXXX-XX";
 		    var cid = uuid.v4();
 		    visitor = ua(tid, cid);
 	    });
-	    
+
 	    it('should not translate params', function(){
 	        var params = {
 	            tid: 1,
@@ -132,64 +132,20 @@ describe("ua", function () {
 	            somefake: 1,
 	            v: 'a'
 	        };
-	        
-	        visitor._translateParams(params).should.eql(params);	    
+
+	        visitor._translateParams(params).should.eql(params);
 	    })
-	    
-	    it('should match all parameters and each should be in the list of accepted', function(){        
+
+	    it('should match all parameters and each should be in the list of accepted', function(){
 	        var res = visitor._translateParams(config.parametersMap);
 	        for (var i in res) {
 	            if (res.hasOwnProperty(i)) {
 	                res[i].should.equal(i);
 	                config.acceptedParameters.should.containEql(i);
 	            }
-	        }	    
+	        }
 	    })
-
-    });
-    
-	describe("#debug", function () {
-
-		var log;
-
-		before(function () {
-			log = sinon.stub(ua.Visitor.prototype, "_log")
-		});
-
-		after(function () {
-			log.restore();
-		});
-
-		it("should enable debugging when invoked without arguments", function () {
-			var visitor = ua().debug()
-
-			visitor.options.debug.should.equal(true);
-
-			visitor.debug().should.equal(visitor, "should return itself")
-
-			visitor.options.debug.should.equal(true, "A second #debug call should leave debugging enabled");
-		});
-
-		it("should toggle debugging when invoked with a boolean arguments", function () {
-			var visitor = ua().debug(true)
-
-			visitor.options.debug.should.equal(true);
-
-			visitor.debug(false).should.equal(visitor, "should return itself")
-
-			visitor.options.debug.should.equal(false);
-		});
 
 	});
 
 });
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
good: better formatting, colors, timings
bad: adds extra dependency
  
But it does seems like a good fit: quite a few among [universal-analytics dependents][2]  are already using [debug].

- remove `_log()` method
- reimplement `visitor.debug()` to enable new debug module, add deprecation warning
- remove tests for `visitor.debug()`

[debug]: https://www.npmjs.com/package/debug
[2]: https://www.npmjs.com/browse/depended/universal-analytics