### PR TITLE
Updated middleware to keep checking for _ga cookie…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,13 +74,13 @@ module.exports.middleware = function (tid, options) {
 
     req.visitor = module.exports.createFromSession(req.session);
 
-    if (req.visitor) return next();
+    if (req.visitor && req.visitor.cid.includes('.')) return next();
 
     var cid;
     if (req.cookies && req.cookies[cookieName]) {
       var gaSplit = req.cookies[cookieName].split('.');
       cid = gaSplit[2] + "." + gaSplit[3];
-    }
+    } else if (req.visitor) return next();
 
     req.visitor = init(tid, cid, options);
 


### PR DESCRIPTION
…when the CID isn't in the form '1381130355.1542129876'. This mitigates the issue where the cookie isn't present on initial page load, the session caches an generated UUID, and frontend & backend events aren't correlated to the same user.
See https://github.com/peaksandpies/universal-analytics/issues/40 for more information.