### PR TITLE
Option to override default instance name

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,10 @@ var app = express()
 express.use(ua.middleware("UA-XXXX-Y", {cookieName: '_ga'}));
 ```
 
-The middleware will attach the `universal analytics` visitor instance to every request (`req.visitor`).
+The middleware will attach the `universal analytics` visitor instance to every request with the default name of `req.visitor`. The name of the instance on the `req` object can be overridden to avoid name conflicts by passing in `instanceName` on the `options` object:
+```javascript
+express.use(ua.middleware("UA-XXXX-Y", {instanceName: 'uaVisitor'}));
+ ```
 
 Additionally, the module also exposes a `createFromSession` method to create a visitor instance simply based on a session, which is helpful when working with Socket.io, etc. where the middleware is not used.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,15 +66,17 @@ var Visitor = module.exports.Visitor = function (tid, cid, options, context, per
 module.exports.middleware = function (tid, options) {
 
   this.tid = tid;
-  this.options = options;
+  this.options = options || {};
 
-  var cookieName = (this.options || {}).cookieName || "_ga";
+  var cookieName = this.options.cookieName || "_ga";
+  var globalName = this.options.nameOverride || "visitor";
+  delete this.options.nameOverride;
 
   return function (req, res, next) {
 
-    req.visitor = module.exports.createFromSession(req.session);
+    req[globalName] = module.exports.createFromSession(req.session);
 
-    if (req.visitor) return next();
+    if (req[globalName]) return next();
 
     var cid;
     if (req.cookies && req.cookies[cookieName]) {
@@ -82,10 +84,10 @@ module.exports.middleware = function (tid, options) {
       cid = gaSplit[2] + "." + gaSplit[3];
     }
 
-    req.visitor = init(tid, cid, options);
+    req[globalName] = init(tid, cid, options);
 
     if (req.session) {
-      req.session.cid = req.visitor.cid;
+      req.session.cid = req[globalName].cid;
     }
 
     next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,14 +69,14 @@ module.exports.middleware = function (tid, options) {
   this.options = options || {};
 
   var cookieName = this.options.cookieName || "_ga";
-  var globalName = this.options.nameOverride || "visitor";
-  delete this.options.nameOverride;
+  var instanceName = this.options.instanceName || "visitor";
+  delete this.options.instanceName;
 
   return function (req, res, next) {
 
-    req[globalName] = module.exports.createFromSession(req.session);
+    req[instanceName] = module.exports.createFromSession(req.session);
 
-    if (req[globalName]) return next();
+    if (req[instanceName]) return next();
 
     var cid;
     if (req.cookies && req.cookies[cookieName]) {
@@ -84,10 +84,10 @@ module.exports.middleware = function (tid, options) {
       cid = gaSplit[2] + "." + gaSplit[3];
     }
 
-    req[globalName] = init(tid, cid, options);
+    req[instanceName] = init(tid, cid, options);
 
     if (req.session) {
-      req.session.cid = req[globalName].cid;
+      req.session.cid = req[instanceName].cid;
     }
 
     next();

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -63,6 +63,17 @@ describe("ua", function () {
 
 			req.visitor.cid.should.equal("46218180.1366882461", "The client ID should've been extracted from the cookie")
 		})
+		
+		it("should allow changing the variable name on req", function() {
+			var req = {cookies: {_ga: "GA1.2.46218180.1366882461"}}
+			var options = {nameOverride: "banana"}
+			var middleware = ua.middleware("tid", options)
+			var next = sinon.spy()
+
+			middleware(req, {}, next)
+
+			req.banana.cid.should.equal("46218180.1366882461", "The request should have the UA visitor instance on the non-default variable name")
+		})
 
 
 		it("should store the cid in the session", function () {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -66,7 +66,7 @@ describe("ua", function () {
 		
 		it("should allow changing the variable name on req", function() {
 			var req = {cookies: {_ga: "GA1.2.46218180.1366882461"}}
-			var options = {nameOverride: "banana"}
+			var options = {instanceName: "banana"}
 			var middleware = ua.middleware("tid", options)
 			var next = sinon.spy()
 


### PR DESCRIPTION
The name of the instance when created through middleware is currently hardcoded to `req.visitor`. This ads an option called `instanceName` that can override the default name to something else to avoid naming conflicts.