### PR TITLE
feat: pin native-request version to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-analytics",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "native-request": "^1.0.5",
+    "native-request": "1.0.5",
     "uuid": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses the concerns expressed [here](https://github.com/peaksandpies/universal-analytics/pull/144#issuecomment-653392524).