### PR TITLE
feat: Use own version of request library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,14 @@
 
-var request = require("native-request");
 var uuid = require("uuid");
 var querystring = require("querystring");
+var url = require("url");
 
 var utils = require("./utils");
 var config = require("./config");
-var url = require("url");
+var request = require('./request');
 
 var debug = require("debug")("universal-analytics");
+
 
 module.exports = init;
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,81 @@
+`use strict`
+
+const http = require('http');
+const https = require('https');
+const url = require('url');
+const debug = require("debug")("universal-analytics");
+
+function getProtocol(path) {
+  return url.parse(path).protocol === "http:" ? http : https;
+}
+
+/**
+ * Send a post request
+ * @param path is the url endpoint
+ * @param headers of the request
+ * @param callback contains (error, body, status, headers)
+ * @param data a JSON Object or a string
+ */
+function post(path, data, headers, callback) {
+  request(path, "POST", data, headers, callback);
+}
+
+/**
+ * Send a custom request
+ * @param path is the url endpoint
+ * @param headers of the request
+ * @param callback contains (error, statusCode, data)
+ * @param data a JSON Object or a string
+ * @param method is the protocol used like POST GET DELETE PUT etc...
+ */
+function request(path, method, data, headers = '', callback) {
+  if (typeof data === 'function') {
+    callback = data;
+    data = '';
+  } else if (typeof headers === 'function') {
+    callback = headers;
+    headers = {};
+  }
+
+  const postData = typeof data === "object" ? JSON.stringify(data) : data;
+  const { hostname, port, pathname } = url.parse(path);
+  const options = {
+    hostname,
+    port,
+    path: pathname,
+    method,
+    headers
+  };
+
+  const req = getProtocol(path).request(options, function (response) {
+    handleResponse(response, callback);
+  });
+
+  req.on('error', function (error) {
+    callback(error);
+    debug('Request error', error);
+  });
+
+  req.write(postData);
+
+  req.end();
+}
+
+function handleResponse(response, callback) {
+  let body = '';
+  const { headers, statusCode, setEncoding } = response
+  const hasError = statusCode >= 300;
+  setEncoding('utf8');
+
+  response.on('data', function (data) {
+    body += data;
+  });
+
+  response.on('end', function () {
+    callback(hasError ? body : null, hasError ? null : body, statusCode, headers);
+  });
+}
+
+module.exports = {
+  post
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,11 +667,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "native-request": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.5.tgz",
-      "integrity": "sha512-7wU3DvBGAJQxWuMR3F62zrhB7hxNj2DdlC/eBVrCgavc6+ZpFZOqS/PsR7QyUPLMkFk0GvvzoeeOAZGLLnObnA=="
-    },
     "nise": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-analytics",
-  "version": "0.4.22",
+  "version": "0.5.0",
   "description": "A node module for Google's Universal Analytics tracking",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "native-request": "1.0.5",
     "uuid": "^8.0.0"
   },
   "devDependencies": {
@@ -27,5 +26,8 @@
     "mocha": "^7.1.2"
   },
   "author": "Jörg Tillmann <joerg@peaksandpies.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=12.18.2"
+  }
 }

--- a/test/_enqueue.js
+++ b/test/_enqueue.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -9,6 +8,7 @@ var url = require("url");
 var ua = require("../lib/index.js");
 var utils = require("../lib/utils.js")
 var config = require("../lib/config.js")
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/event.js
+++ b/test/event.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -9,6 +8,7 @@ var url = require("url");
 var ua = require("../lib/index.js");
 var utils = require("../lib/utils.js")
 var config = require("../lib/config.js")
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/exception.js
+++ b/test/exception.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/item.js
+++ b/test/item.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/pageview.js
+++ b/test/pageview.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/send.js
+++ b/test/send.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -9,6 +8,7 @@ var url = require("url");
 var ua = require("../lib/index.js");
 var utils = require("../lib/utils.js")
 var config = require("../lib/config.js")
+var request = require("../lib/request.js");
 
 
 describe("ua", function () {

--- a/test/set.js
+++ b/test/set.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/timing.js
+++ b/test/timing.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -1,5 +1,4 @@
 
-var request = require("native-request");
 var qs = require("querystring");
 var uuid = require("uuid");
 var should = require("should");
@@ -7,8 +6,9 @@ var sinon = require("sinon");
 var url = require("url");
 
 var ua = require("../lib/index.js");
-var utils = require("../lib/utils.js")
-var config = require("../lib/config.js")
+var utils = require("../lib/utils.js");
+var config = require("../lib/config.js");
+var request = require("../lib/request");
 
 
 describe("ua", function () {


### PR DESCRIPTION
- Removed the `native-request` dependency
- Bumped package version to 0.5.0
- Added requirement to use current LTS of Node, to make sure ES6 features work (Thoughts?)

All tests still run but I haven't actually tried it in a "production" environment.

I looked at also removing the UUID and debug dependencies, but decided it was too much work for me right now. It would either way require external dependencies, since UUID requires crypto libraries etc. I didn't want to dive too deep in to that rabbit hole.